### PR TITLE
Integrate ForjaElo prompts and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Cada mensagem em fila espera um atraso configurável antes de ser enviada. Use *
 
 Os modelos de prompt padrão vêm de `prompts.js`. Edite esse arquivo para adicionar ou modificar os prompts exibidos no menu. Recarregue a extensão após as alterações para ver suas entradas personalizadas.
 
+O pacote já traz integrado um conjunto de prompts **ForjaElo** (SSA, Scorecard, Devocional, Processo, Roteiro e Detox), facilitando a automação dos fluxos descritos no guia.
+
 ### Exportar Logs
 
 Para solucionar problemas, a extensão grava logs do console do script de conteúdo. Cada entrada indica o **nível** (info ou error) para facilitar a análise. Clique em **Exportar Logs** no popup para baixar um arquivo JSON com as entradas recentes.

--- a/background.js
+++ b/background.js
@@ -80,7 +80,13 @@ const toolKeywords = {
   'Pensar por mais tempo': ['pensar', 'por', 'mais', 'tempo'],
   'Investigar': ['investigar'],
   'Busca na Web': ['busca', 'na', 'web'],
-  'Lousa': ['lousa']
+  'Lousa': ['lousa'],
+  'ForjaElo · SSA (Organizador)': ['forjaelo', 'ssa'],
+  'ForjaElo · Scorecard (CSV)': ['forjaelo', 'scorecard'],
+  'ForjaElo · Devocional 15min': ['forjaelo', 'devocional', '15'],
+  'ForjaElo · Processo em 7 passos': ['forjaelo', 'processo', '7'],
+  'ForjaElo · Roteiro Ide (90s)': ['forjaelo', 'roteiro', 'ide'],
+  'ForjaElo · Detox 24h': ['forjaelo', 'detox', '24h']
 };
 
 function detectTool(prompt) {

--- a/content.js
+++ b/content.js
@@ -146,7 +146,13 @@ const toolKeywords = {
   'Pensar por mais tempo': ['pensar', 'por', 'mais', 'tempo'],
   'Investigar': ['investigar'],
   'Busca na Web': ['busca', 'na', 'web'],
-  'Lousa': ['lousa']
+  'Lousa': ['lousa'],
+  'ForjaElo · SSA (Organizador)': ['forjaelo', 'ssa'],
+  'ForjaElo · Scorecard (CSV)': ['forjaelo', 'scorecard'],
+  'ForjaElo · Devocional 15min': ['forjaelo', 'devocional', '15'],
+  'ForjaElo · Processo em 7 passos': ['forjaelo', 'processo', '7'],
+  'ForjaElo · Roteiro Ide (90s)': ['forjaelo', 'roteiro', 'ide'],
+  'ForjaElo · Detox 24h': ['forjaelo', 'detox', '24h']
 };
 
 function detectTool(prompt) {

--- a/prompts.js
+++ b/prompts.js
@@ -1,7 +1,9 @@
-const prompts = [
+// prompts.js — inclui prompts padrão e o pacote ForjaElo
+
+const BASE_PROMPTS = [
   {
     title: "Realizar pesquisa de empresas de IA",
-    text: `Utilizando sua capacidade de busca na web, procure as informações mais recentes sobre empresas de capital aberto que estejam se beneficiando do crescimento da IA. Inclua colunas de URL onde eu possa saber mais sobre cada empresa, suas vantagens competitivas e eventuais avaliações de analistas. Retorne tudo em uma tabela inline. Pesquisaremos em lotes de 10; quando eu disser "Mais", encontre mais 10. Mantenha as informações resumidas e todas dentro da tabela. Exemplo: | Nome da Empresa | Símbolo | Vantagens Competitivas | Avaliação de Analistas | URL | ... Por favor, forneça as informações mais recentes disponíveis. ~Mais ~ Mais ~ Mais`
+    text: `Utilizando sua capacidade de busca na web, procure as informações mais recentes sobre empresas de capital aberto que estejam se beneficiando do crescimento da IA. Inclua colunas de URL onde eu possa saber mais sobre cada empresa, suas vantagens competitivas e eventuais avaliações de analistas. Retorne tudo em uma tabela inline. Pesquisaremos em lotes de 10; quando eu disser "Mais", encontre mais 10. Mantenha as informações resumidas e todas dentro da tabela. Exemplo: | Nome da Empresa | Símbolo | Vantagens Competitivas | Avaliação de Analistas | URL | ... Por favor, forneça as informações mais recentes disponíveis. ~Mais~ Mais ~ Mais`
   },
   {
     title: "Como ganhar um milhão de dólares com suas habilidades",
@@ -9,6 +11,52 @@ const prompts = [
   },
   {
     title: "Gerar afirmações positivas",
-    text: `{USER_NAME}=Nome do usuário\n{USER_TRAITS}=Lista de traços ou qualidades positivas do usuário\n{USER_GOALS}=Principais objetivos ou aspirações do usuário\n\nCom base nas informações do usuário, resuma os principais traços e objetivos.\nDiante dos seguintes detalhes sobre [USER_NAME]—traços positivos: [USER_TRAITS]; objetivos principais: [USER_GOALS]—crie um breve resumo que servirá de contexto para gerar afirmações\n\n ~ Crie afirmações focadas em aumentar a autoconfiança, a motivação e o senso de valor pessoal com base nas qualidades e metas do usuário.\n"Usando esse contexto: [SUMMARY_FROM_STEP_1], gere [AFFIRMATION_COUNT] afirmações que incentivem a crença em si mesmo e ações positivas. Garanta que cada afirmação reflita um dos traços ou objetivos do usuário e seja direta e motivadora."\n\n~ Melhore cada afirmação adicionando linguagem emocionalmente forte para torná-la impactante e fácil de internalizar.\n"Para cada afirmação em [AFFIRMATIONS_FROM_STEP_2], aperfeiçoe-a com palavras encorajadoras e deixe-a concisa. Certifique-se de que esteja no tempo presente, de modo que o usuário se sinta estimulado no momento."\n\n~ Revise e ajuste as afirmações para garantir que sejam motivadoras e alinhadas à jornada pessoal de [USER_NAME].\n"Revise a lista de afirmações e faça quaisquer ajustes finais para garantir que soem naturais, positivas e diretamente relacionadas ao crescimento e às metas pessoais de [USER_NAME].`
+    text: `{USER_NAME}=Nome do usuário\n{USER_TRAITS}=Lista de traços ou qualidades positivas do usuário\n{USER_GOALS}=Principais objetivos ou aspirações do usuário\n\nCom base nas informações do usuário, resuma os principais traços e objetivos.\nDiante dos seguintes detalhes sobre [USER_NAME]—traços positivos: [USER_TRAITS]; objetivos principais: [USER_GOALS]—crie um breve resumo que servirá de contexto para gerar afirmações\n\n ~ Crie afirmações focadas em aumentar a autoconfiança, a motivação e o senso de valor pessoal com base nas qualidades e metas do usuário.\n"Usando esse contexto: [SUMMARY_FROM_STEP_1], gere [AFFIRMATION_COUNT] afirmações que incentivem a crença em si mesmo e ações positivas. Garanta que cada afirmação reflita um dos traços ou objetivos do usuário e seja direta e motivadora."\n\n~ Melhore cada afirmação adicionando linguagem emocionalmente forte para torná-la impactante e fácil de internalizar.\n"Para cada afirmação em [AFFIRMATIONS_FROM_STEP_2], aperfeiçoe-a com palavras encorajadoras e deixe-a concisa. Certifique-se de que esteja no tempo presente, de modo que o usuário se sinta estimulado no momento."\n\n~Revise e ajuste as afirmações para garantir que sejam motivadoras e alinhadas à jornada pessoal de [USER_NAME].\n"Revise a lista de afirmações e faça quaisquer ajustes finais para garantir que soem naturais, positivas e diretamente relacionadas ao crescimento e às metas pessoais de [USER_NAME].`
   }
 ];
+
+// Pacote de prompts da ForjaElo
+window.FORJA_PROMPTS = [
+  {
+    title: "ForjaElo · SSA (Organizador)",
+    text: `Você é o Servo sem alma (SSA). Apenas organiza, verifica e padroniza meu material.
+Não proponha objetivos, visão ou conteúdo novo sem minha direção explícita.
+Peça insumos se faltarem dados. Priorize privacidade e listas curtas.
+Formato-padrão:
+1) Objetivo (1 frase)
+2) 3 passos mínimos
+3) Travas + Sprint10
+Material: <<<COLAR AQUI>>>`
+  },
+  {
+    title: "ForjaElo · Scorecard (CSV)",
+    text: `Gere CSV com cabeçalhos e validações simples para o scorecard semanal.
+Campos: Data,EloDoDia,Top1_Proposito,Top2_Resultado,Top3_Elo,Leveza_1a5,EntregasElo,Devocional_Aplicacao,Convites,Fechamentos,DispersaoMin,Observacoes
+Produza apenas o CSV, sem comentários.`
+  },
+  {
+    title: "ForjaElo · Devocional 15min",
+    text: `Monte um esboço de 15 min: 3 pontos (bíblico→prático→apelo), 2 versos, 1 desafio 24h.
+Use SOMENTE meu rascunho:
+<<<COLAR RASCUNHO>>>`
+  },
+  {
+    title: "ForjaElo · Processo em 7 passos",
+    text: `Liste 7 passos (1 linha cada), com tempo estimado e checagem. Baseie-se apenas no texto:
+<<<COLAR BASE>>>`
+  },
+  {
+    title: "ForjaElo · Roteiro Ide (90s)",
+    text: `Escreva um convite/evangelismo de 90s. Use APENAS meu material.
+<<<COLAR PONTOS>>>`
+  },
+  {
+    title: "ForjaElo · Detox 24h",
+    text: `Transforme esta lista de 'drenos' em protocolo de desintoxicação 24h (digital, emocional, espiritual) em 5 passos.
+<<<COLAR LISTA>>>`
+  }
+];
+
+// Combina prompts existentes com os da ForjaElo
+const prompts = [...BASE_PROMPTS, ...window.FORJA_PROMPTS];
+

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -14,6 +14,7 @@ const utils = require('../utils');
   // detectTool
   assert.strictEqual(utils.detectTool('Criar imagem para teste'), 'Criar imagem');
   assert.strictEqual(utils.detectTool('Investigar   situação'), 'Investigar');
+  assert.strictEqual(utils.detectTool('ForjaElo scorecard em csv agora'), 'ForjaElo · Scorecard (CSV)');
   assert.strictEqual(utils.detectTool('texto sem ferramenta'), '');
 
   // randomDelay

--- a/utils.js
+++ b/utils.js
@@ -30,7 +30,13 @@
     'Pensar por mais tempo': ['pensar', 'por', 'mais', 'tempo'],
     'Investigar': ['investigar'],
     'Busca na Web': ['busca', 'na', 'web'],
-    'Lousa': ['lousa']
+    'Lousa': ['lousa'],
+    'ForjaElo · SSA (Organizador)': ['forjaelo', 'ssa'],
+    'ForjaElo · Scorecard (CSV)': ['forjaelo', 'scorecard'],
+    'ForjaElo · Devocional 15min': ['forjaelo', 'devocional', '15'],
+    'ForjaElo · Processo em 7 passos': ['forjaelo', 'processo', '7'],
+    'ForjaElo · Roteiro Ide (90s)': ['forjaelo', 'roteiro', 'ide'],
+    'ForjaElo · Detox 24h': ['forjaelo', 'detox', '24h']
   };
 
   function detectTool(prompt) {


### PR DESCRIPTION
## Summary
- add ForjaElo prompt pack with SSA, scorecard, devocional, processo, roteiro and detox templates
- extend tool detection in background, content and utils to recognize ForjaElo commands
- test detection for ForjaElo scorecard prompt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f1ea7a9c83318e8c2646258414c6