### PR TITLE
Remove tool selection from popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -199,7 +199,6 @@
       cola o texto, inicia a automação e copia o resultado automaticamente.
     </p>
 
-    <!-- Ferramenta e Modo removidos -->
     <!-- Prompts em Lote -->
     <h2>Adicionar prompts em lote</h2>
     <div id="bulkInput">
@@ -304,8 +303,6 @@
         <tr><td>Enfileirar</td><td><input id="scQueue" placeholder="Ctrl+Enter"></td></tr>
         <tr><td>Limpar Fila</td><td><input id="scClearQueue" placeholder="Ctrl+Shift+C"></td></tr>
         <tr><td>Copiar Prompt</td><td><input id="scCopyPrompt" placeholder="Ctrl+Shift+P"></td></tr>
-        <tr><td>Aplicar Ferramenta</td><td><input id="scApplyTool" placeholder="Ctrl+Shift+2"></td></tr>
-        <tr><td colspan="2"><small>Identifica a ferramenta se as cinco primeiras palavras copiadas contiverem suas palavras-chave.</small></td></tr>
         <tr><td>Salvar Nota</td><td><input id="scSaveNote" placeholder="Ctrl+S"></td></tr>
         <tr><td>Carregar Nota</td><td><input id="scLoadNote" placeholder="Ctrl+O"></td></tr>
         <tr><td>Exportar JSON</td><td><input id="scExportJson" placeholder="Ctrl+Shift+J"></td></tr>

--- a/popup.js
+++ b/popup.js
@@ -95,7 +95,6 @@ document.addEventListener('DOMContentLoaded', () => {
     scQueue: 'scQueue',
     scClearQueue: 'scClearQueue',
     scCopyPrompt: 'scCopyPrompt',
-    scApplyTool: 'scApplyTool',
     scSaveNote: 'scSaveNote',
     scLoadNote: 'scLoadNote',
     scExportJson: 'scExportJson',
@@ -144,7 +143,6 @@ document.addEventListener('DOMContentLoaded', () => {
     els.scQueue,
     els.scClearQueue,
     els.scCopyPrompt,
-    els.scApplyTool,
     els.scSaveNote,
     els.scLoadNote,
     els.scExportJson,
@@ -232,7 +230,6 @@ document.addEventListener('DOMContentLoaded', () => {
     els.scQueue.value = shortcuts.queue;
     els.scClearQueue.value = shortcuts.clearQueue;
     els.scCopyPrompt.value = shortcuts.copyPrompt;
-    els.scApplyTool.value = shortcuts.applyTool;
     els.scSaveNote.value = shortcuts.saveNote;
     els.scLoadNote.value = shortcuts.loadNote;
     els.scExportJson.value = shortcuts.exportJson;
@@ -492,10 +489,10 @@ document.addEventListener('DOMContentLoaded', () => {
   els.saveShortcuts.addEventListener('click', () => {
     showLoading();
     shortcuts = {
+      ...shortcuts,
       queue: els.scQueue.value || defaultShortcuts.queue,
       clearQueue: els.scClearQueue.value || defaultShortcuts.clearQueue,
       copyPrompt: els.scCopyPrompt.value || defaultShortcuts.copyPrompt,
-      applyTool: els.scApplyTool.value || defaultShortcuts.applyTool,
       saveNote: els.scSaveNote.value || defaultShortcuts.saveNote,
       loadNote: els.scLoadNote.value || defaultShortcuts.loadNote,
       exportJson: els.scExportJson.value || defaultShortcuts.exportJson,
@@ -523,7 +520,6 @@ document.addEventListener('DOMContentLoaded', () => {
     els.scQueue.value = shortcuts.queue;
     els.scClearQueue.value = shortcuts.clearQueue;
     els.scCopyPrompt.value = shortcuts.copyPrompt;
-    els.scApplyTool.value = shortcuts.applyTool;
     els.scSaveNote.value = shortcuts.saveNote;
     els.scLoadNote.value = shortcuts.loadNote;
     els.scExportJson.value = shortcuts.exportJson;
@@ -589,8 +585,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const bgText = bg.status || 'serviço em segundo plano ocioso';
       sendToActiveTab({ action: 'status' }, (ct) => {
         const ctText = ct?.status ? `${ct.status} - queue: ${ct.queueLength}` : 'script de conteúdo ocioso';
-        const toolText = ct?.active ? ` - tool: ${ct.active}` : '';
-        els.serviceStatus.textContent = `${bgText} | ${ctText}${toolText}`;
+        const modeText = ' - modo teclado';
+        els.serviceStatus.textContent = `${bgText} | ${ctText}${modeText}`;
       });
     });
   };


### PR DESCRIPTION
## Summary
- Remove Ferramenta & Modo section and shortcut input from popup
- Show keyboard mode in service status

## Testing
- `node test/run-tests.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f65677b4833183d1aff33338d245