### PR TITLE
Remove automation shortcut message from popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -194,9 +194,7 @@
       Configure os atalhos globais em
       <a id="openShortcuts" href="#">chrome://extensions/shortcuts</a>.<br>
       Ativos: Abrir ChatGPT rapidamente (Ctrl+Shift+1), Aplicar e Automatizar (Ctrl+Shift+2),
-      Colar texto e iniciar automação (Ctrl+Shift+3), Copiar JSON do resultado (Ctrl+Shift+4).<br>
-      O atalho "Aplicar e Automatizar" detecta a ferramenta nas cinco primeiras palavras copiadas,
-      cola o texto, inicia a automação e copia o resultado automaticamente.
+      Colar texto e iniciar automação (Ctrl+Shift+3), Copiar JSON do resultado (Ctrl+Shift+4).
     </p>
 
     <!-- Prompts em Lote -->


### PR DESCRIPTION
## Summary
- remove outdated description of "Aplicar e Automatizar" shortcut from popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f978027c8331a2a05f7acbaec1b3