### PR TITLE
refactor: organize prompts by extension feature

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -262,12 +262,18 @@ document.addEventListener('DOMContentLoaded', () => {
     els.note.value = res.savedNote || '';
   });
 
-  // Populate promptSelect
-  prompts.forEach((p, i) => {
-    const opt = document.createElement('option');
-    opt.value = i;
-    opt.textContent = p.title;
-    els.promptSelect.appendChild(opt);
+  // Populate promptSelect com grupos de prompts
+  const promptGroups = window.PROMPT_GROUPS || [];
+  promptGroups.forEach((group, gIdx) => {
+    const og = document.createElement('optgroup');
+    og.label = group.label;
+    group.items.forEach((p, pIdx) => {
+      const opt = document.createElement('option');
+      opt.value = `${gIdx}:${pIdx}`;
+      opt.textContent = p.title;
+      og.appendChild(opt);
+    });
+    els.promptSelect.appendChild(og);
   });
 
   // --- Event Listeners --------------------------------------------------------
@@ -324,9 +330,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // Copy prompt
   els.copyPrompt.addEventListener('click', () => {
     showLoading();
-    const idx = parseInt(els.promptSelect.value, 10);
-    if (isNaN(idx) || !prompts[idx]) return hideLoading();
-    navigator.clipboard.writeText(prompts[idx].text).then(() => {
+    const [gIdx, pIdx] = (els.promptSelect.value || '').split(':').map(Number);
+    const group = promptGroups[gIdx];
+    const prompt = group && group.items[pIdx];
+    if (!prompt) return hideLoading();
+    navigator.clipboard.writeText(prompt.text).then(() => {
       els.status.textContent = 'Prompt copiado';
       setTimeout(() => (els.status.textContent = ''), 1000);
       hideLoading();

--- a/prompts.js
+++ b/prompts.js
@@ -16,7 +16,7 @@ const BASE_PROMPTS = [
 ];
 
 // Pacote de prompts da ForjaElo
-window.FORJA_PROMPTS = [
+const FORJA_PROMPTS = [
   {
     title: "ForjaElo · SSA (Organizador)",
     text: `Você é o Servo sem alma (SSA). Apenas organiza, verifica e padroniza meu material.
@@ -57,6 +57,10 @@ Use SOMENTE meu rascunho:
   }
 ];
 
-// Combina prompts existentes com os da ForjaElo
-const prompts = [...BASE_PROMPTS, ...window.FORJA_PROMPTS];
+// Estrutura os prompts por grupos para facilitar o uso no popup
+window.PROMPT_GROUPS = [
+  { label: 'Prompts Padrão', items: BASE_PROMPTS },
+  { label: 'ForjaElo', items: FORJA_PROMPTS }
+];
+
 


### PR DESCRIPTION
## Summary
- structure prompts into groups for standard and ForjaElo features
- populate prompt selector with optgroups and handle grouped selections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6082637508331b231e3215a8ea301