### PR TITLE
Remover prompts padrão e manter apenas ForjaElo

### DIFF
--- a/background.js
+++ b/background.js
@@ -76,11 +76,6 @@ function getFirstFiveWords(prompt) {
 }
 
 const toolKeywords = {
-  'Criar imagem': ['criar', 'imagem'],
-  'Pensar por mais tempo': ['pensar', 'por', 'mais', 'tempo'],
-  'Investigar': ['investigar'],
-  'Busca na Web': ['busca', 'na', 'web'],
-  'Lousa': ['lousa'],
   'ForjaElo · SSA (Organizador)': ['forjaelo', 'ssa'],
   'ForjaElo · Scorecard (CSV)': ['forjaelo', 'scorecard'],
   'ForjaElo · Devocional 15min': ['forjaelo', 'devocional', '15'],

--- a/content.js
+++ b/content.js
@@ -43,10 +43,6 @@ let shortcuts = {
   queue: 'Ctrl+Enter',
   select: 'Ctrl+Shift+S',
   run: 'Ctrl+Shift+R',
-  toolImage: 'Ctrl+Shift+1',
-  toolInvestigate: 'Ctrl+Shift+3',
-  toolSearch: 'Ctrl+Shift+4',
-  toolWhiteboard: 'Ctrl+Shift+5',
   pasteStart: 'Ctrl+Shift+V',
   pasteStartAutomation: 'Ctrl+Shift+H',
   startAutomation: 'Ctrl+Shift+G',
@@ -142,11 +138,6 @@ function queuePromptsFromResponse(text) {
 }
 
 const toolKeywords = {
-  'Criar imagem': ['criar', 'imagem'],
-  'Pensar por mais tempo': ['pensar', 'por', 'mais', 'tempo'],
-  'Investigar': ['investigar'],
-  'Busca na Web': ['busca', 'na', 'web'],
-  'Lousa': ['lousa'],
   'ForjaElo · SSA (Organizador)': ['forjaelo', 'ssa'],
   'ForjaElo · Scorecard (CSV)': ['forjaelo', 'scorecard'],
   'ForjaElo · Devocional 15min': ['forjaelo', 'devocional', '15'],
@@ -1326,22 +1317,6 @@ function handleShortcut(e) {
     e.preventDefault();
     showShortcutInfo(`Atalho ${combo}`);
     runCustomClicks();
-  } else if (combo === shortcuts.toolImage) {
-    e.preventDefault();
-    showShortcutInfo(`Atalho ${combo}`);
-    selectTool('Criar imagem');
-  } else if (combo === shortcuts.toolInvestigate) {
-    e.preventDefault();
-    showShortcutInfo(`Atalho ${combo}`);
-    selectTool('Investigar');
-  } else if (combo === shortcuts.toolSearch) {
-    e.preventDefault();
-    showShortcutInfo(`Atalho ${combo}`);
-    selectTool('Busca na Web');
-  } else if (combo === shortcuts.toolWhiteboard) {
-    e.preventDefault();
-    showShortcutInfo(`Atalho ${combo}`);
-    selectTool('Lousa');
   } else if (combo === shortcuts.pasteStart) {
     e.preventDefault();
     showShortcutInfo(`Atalho ${combo}`);

--- a/prompts.js
+++ b/prompts.js
@@ -1,21 +1,6 @@
-// prompts.js — inclui prompts padrão e o pacote ForjaElo
+// prompts.js — inclui apenas os prompts da ForjaElo
 
-const BASE_PROMPTS = [
-  {
-    title: "Realizar pesquisa de empresas de IA",
-    text: `Utilizando sua capacidade de busca na web, procure as informações mais recentes sobre empresas de capital aberto que estejam se beneficiando do crescimento da IA. Inclua colunas de URL onde eu possa saber mais sobre cada empresa, suas vantagens competitivas e eventuais avaliações de analistas. Retorne tudo em uma tabela inline. Pesquisaremos em lotes de 10; quando eu disser "Mais", encontre mais 10. Mantenha as informações resumidas e todas dentro da tabela. Exemplo: | Nome da Empresa | Símbolo | Vantagens Competitivas | Avaliação de Analistas | URL | ... Por favor, forneça as informações mais recentes disponíveis. ~Mais~ Mais ~ Mais`
-  },
-  {
-    title: "Como ganhar um milhão de dólares com suas habilidades",
-    text: `[Skill Set] = Uma breve descrição de suas principais habilidades e especialidades [Time Frame] = O período desejado para atingir um milhão de dólares [Available Resources] = Recursos atualmente disponíveis [Interests] = Interesses pessoais que podem ser aproveitados ~ Passo 1: Com base nas seguintes habilidades: {Skill Set}, identifique as três habilidades com maior demanda no mercado e que podem ser monetizadas de forma eficaz. ~ Passo 2: Para cada uma das três habilidades identificadas, liste estratégias de monetização que possam gerar renda significativa dentro de {Time Frame}. Use listas numeradas para clareza. ~ Passo 3: Diante dos recursos disponíveis: {Available Resources}, determine como eles podem ser utilizados para apoiar as estratégias listadas. Forneça exemplos específicos. ~ Passo 4: Considere seus interesses pessoais: {Interests}. Sugira formas de integrar esses interesses às estratégias de monetização para aumentar a motivação e a sustentabilidade. ~ Passo 5: Crie um plano de ação passo a passo delineando as tarefas principais necessárias para implementar as estratégias escolhidas. Organize o plano em uma linha do tempo para alcançar o objetivo dentro de {Time Frame}. ~ Passo 6: Identifique possíveis desafios e obstáculos que possam surgir durante a execução do plano. Dê sugestões de como superá-los. ~ Passo 7: Revise o plano de ação e ajuste-o para garantir que seja realista, alcançável e alinhado às suas habilidades e recursos. Faça ajustes quando necessário.`
-  },
-  {
-    title: "Gerar afirmações positivas",
-    text: `{USER_NAME}=Nome do usuário\n{USER_TRAITS}=Lista de traços ou qualidades positivas do usuário\n{USER_GOALS}=Principais objetivos ou aspirações do usuário\n\nCom base nas informações do usuário, resuma os principais traços e objetivos.\nDiante dos seguintes detalhes sobre [USER_NAME]—traços positivos: [USER_TRAITS]; objetivos principais: [USER_GOALS]—crie um breve resumo que servirá de contexto para gerar afirmações\n\n ~ Crie afirmações focadas em aumentar a autoconfiança, a motivação e o senso de valor pessoal com base nas qualidades e metas do usuário.\n"Usando esse contexto: [SUMMARY_FROM_STEP_1], gere [AFFIRMATION_COUNT] afirmações que incentivem a crença em si mesmo e ações positivas. Garanta que cada afirmação reflita um dos traços ou objetivos do usuário e seja direta e motivadora."\n\n~ Melhore cada afirmação adicionando linguagem emocionalmente forte para torná-la impactante e fácil de internalizar.\n"Para cada afirmação em [AFFIRMATIONS_FROM_STEP_2], aperfeiçoe-a com palavras encorajadoras e deixe-a concisa. Certifique-se de que esteja no tempo presente, de modo que o usuário se sinta estimulado no momento."\n\n~Revise e ajuste as afirmações para garantir que sejam motivadoras e alinhadas à jornada pessoal de [USER_NAME].\n"Revise a lista de afirmações e faça quaisquer ajustes finais para garantir que soem naturais, positivas e diretamente relacionadas ao crescimento e às metas pessoais de [USER_NAME].`
-  }
-];
-
-// Pacote de prompts da ForjaElo
+// Prompts da ForjaElo
 const FORJA_PROMPTS = [
   {
     title: "ForjaElo · SSA (Organizador)",
@@ -115,7 +100,6 @@ Use SOMENTE meu rascunho:
 
 // Estrutura os prompts por grupos para facilitar o uso no popup
 window.PROMPT_GROUPS = [
-  { label: 'Prompts Padrão', items: BASE_PROMPTS },
   { label: 'ForjaElo', items: FORJA_PROMPTS }
 ];
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,8 +12,6 @@ const utils = require('../utils');
   assert.deepStrictEqual(utils.splitMessages('a ~ b ~~ c '), ['a', 'b', 'c']);
 
   // detectTool
-  assert.strictEqual(utils.detectTool('Criar imagem para teste'), 'Criar imagem');
-  assert.strictEqual(utils.detectTool('Investigar   situação'), 'Investigar');
   assert.strictEqual(utils.detectTool('ForjaElo scorecard em csv agora'), 'ForjaElo · Scorecard (CSV)');
   assert.strictEqual(utils.detectTool('texto sem ferramenta'), '');
 

--- a/utils.js
+++ b/utils.js
@@ -26,11 +26,6 @@
   }
 
   const toolKeywords = {
-    'Criar imagem': ['criar', 'imagem'],
-    'Pensar por mais tempo': ['pensar', 'por', 'mais', 'tempo'],
-    'Investigar': ['investigar'],
-    'Busca na Web': ['busca', 'na', 'web'],
-    'Lousa': ['lousa'],
     'ForjaElo · SSA (Organizador)': ['forjaelo', 'ssa'],
     'ForjaElo · Scorecard (CSV)': ['forjaelo', 'scorecard'],
     'ForjaElo · Devocional 15min': ['forjaelo', 'devocional', '15'],


### PR DESCRIPTION
## Summary
- Remove prompts padrão, mantendo somente os templates da ForjaElo
- Atualiza utilitários e scripts para reconhecer apenas ferramentas ForjaElo
- Ajusta testes para refletir a remoção dos prompts padrão

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a66d0b8bf88331bd9ce4e25e1bb47a